### PR TITLE
Update adb uninstall command

### DIFF
--- a/bin/adb.rb
+++ b/bin/adb.rb
@@ -96,7 +96,7 @@ module ADB
   FAIL = "Failure"
 
   def ADB.uninstall(pkg=PKG)
-    sync_msg("#{@@acmd} uninstall #{pkg}", [SUCC, FAIL])
+    sync_msg("#{@@acmd} shell pm uninstall #{pkg}", [SUCC, FAIL])
   end
 
   def ADB.install(apk)


### PR DESCRIPTION
As of adb v1.0.31, the uninstall command is no longer available.
